### PR TITLE
fixed broken image assets on post preview page

### DIFF
--- a/app/assets/javascripts/facebox.js.erb
+++ b/app/assets/javascripts/facebox.js.erb
@@ -84,8 +84,8 @@
     settings: {
       opacity      : 0.2,
       overlay      : true,
-      loadingImage : '/assets/loading.gif',
-      closeImage   : '/assets/close_icon.png',
+      loadingImage : "<%= asset_path('loading.gif') %>",
+      closeImage   : "<%= asset_path('close_icon.png') %>",
       imageTypes   : [ 'png', 'jpg', 'jpeg', 'gif' ],
       faceboxHtml  : '\
     <div id="facebox" style="display:none;"> \


### PR DESCRIPTION
Hello Team,

This PR has changes for fixing 2 broken image assets ('close_icon.png' and 'loading.gif') on post's preview page. Please refer screenshots below.

Thanks,
Tushar Titame

![broken_close_icon](https://cloud.githubusercontent.com/assets/11384876/7940334/d2bda968-096d-11e5-8beb-d29302b73841.png)
![fixed_close_icon](https://cloud.githubusercontent.com/assets/11384876/7940347/e259d4fa-096d-11e5-933a-0035bd696d4d.png)
